### PR TITLE
Fix 32-bit compilation for DX12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0048 NEW)
 cmake_policy(SET CMP0091 NEW)
 project(ingame_overlay)
-cmake_minimum_required(VERSION 3.15)
 
 if(WIN32) # Setup some variables for Windows build
   set(INGAMEOVERLAY_SOURCES


### PR DESCRIPTION
Currently 32-bit compilation triggers a static_assert failure in ImGui DX12 implementation `imgui_impl_dx12.cpp::464`

https://github.com/Nemirtingas/imgui/blob/d479e20744c36946fd97d416a9be630f3f4d4ab8/backends/imgui_impl_dx12.cpp#L456-L464

Their official solution (also in their example) is to use `/D ImTextureID=ImU64`.
After this change it built successfully for 64 and 32