### PR TITLE
Fix 32-bit compilation on Windows + Linux

### DIFF
--- a/src/Linux/VulkanHook.cpp
+++ b/src/Linux/VulkanHook.cpp
@@ -785,7 +785,7 @@ void VulkanHook_t::_PrepareForOverlay(VkQueue queue, const VkPresentInfoKHR* pPr
         init_info.Device = _VulkanDevice;
         init_info.QueueFamily = _VulkanQueueFamily;
         init_info.Queue = _VulkanQueue;
-        init_info.PipelineCache = nullptr;
+        init_info.PipelineCache = VK_NULL_HANDLE;
         init_info.FontDescriptorSet = _ImGuiFontDescriptor.DescriptorSet;
         init_info.Subpass = 0;
         init_info.MinImageCount = _Frames.size();

--- a/src/Windows/VulkanHook.cpp
+++ b/src/Windows/VulkanHook.cpp
@@ -782,7 +782,7 @@ void VulkanHook_t::_PrepareForOverlay(VkQueue queue, const VkPresentInfoKHR* pPr
         init_info.Device = _VulkanDevice;
         init_info.QueueFamily = _VulkanQueueFamily;
         init_info.Queue = _VulkanQueue;
-        init_info.PipelineCache = nullptr;
+        init_info.PipelineCache = VK_NULL_HANDLE;
         init_info.FontDescriptorSet = _ImGuiFontDescriptor.DescriptorSet;
         init_info.Subpass = 0;
         init_info.MinImageCount = _Frames.size();


### PR DESCRIPTION
This line won't compile with 32-bit compilation
https://github.com/Nemirtingas/ingame_overlay/blob/5fdfde1ad0859ddca2dad34b5ff0f615c710366f/src/Windows/VulkanHook.cpp#L785

`VkPipelineCache` is defined via a macro
https://github.com/Nemirtingas/ingame_overlay/blob/5fdfde1ad0859ddca2dad34b5ff0f615c710366f/src/VulkanSDK/include/vulkan/vulkan_core.h#L114

The macro `VK_DEFINE_NON_DISPATCHABLE_HANDLE` becomes either a pointer (on 64-bit) or a uint64 (on 32-bit)
https://github.com/Nemirtingas/ingame_overlay/blob/5fdfde1ad0859ddca2dad34b5ff0f615c710366f/src/VulkanSDK/include/vulkan/vulkan_core.h#L54-L60

And `VK_NULL_HANDLE` is defined appropriately according to the bit-ness to solve that
https://github.com/Nemirtingas/ingame_overlay/blob/5fdfde1ad0859ddca2dad34b5ff0f615c710366f/src/VulkanSDK/include/vulkan/vulkan_core.h#L38-L51
