### PR TITLE
Add 32-bit builds to the workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    # on any push
+  workflow_dispatch:
+    # allows manual trigger
+
 jobs:
   job:
     name: ${{ matrix.os }}-cmake-build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' && matrix.platform == 'x32' }}
         shell: powershell
         run: |
-          cmake ${{ github.workspace }}\CMakeLists.txt -DINGAMEOVERLAY_BUILD_TESTS=ON -DIMGUI_USER_CONFIG=${{github.workspace}}\tests\common\ingameoverlay_imconfig.h -S . -B build -A Win32
+          cmake ${{ github.workspace }}\CMakeLists.txt -DINGAMEOVERLAY_BUILD_TESTS=OFF -DIMGUI_USER_CONFIG=${{github.workspace}}\tests\common\ingameoverlay_imconfig.h -S . -B build -A Win32
           cmake --build build
           #Get-ChildItem -Recurse build
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
             
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   job:
-    name: ${{ matrix.os }}-cmake-build
+    name: ${{ matrix.os }}-${{ matrix.platform }}-cmake-build
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
           set( CMAKE_CXX_FLAGS_INIT "-m32" )
           EOL
 
-          cmake ${{ github.workspace }}/CMakeLists.txt -DCMAKE_TOOLCHAIN_FILE="cmake_32_build.toolchain" -DINGAMEOVERLAY_BUILD_TESTS=ON -DIMGUI_USER_CONFIG=${{github.workspace}}/tests/common/ingameoverlay_imconfig.h -S . -B build
+          cmake ${{ github.workspace }}/CMakeLists.txt -DCMAKE_TOOLCHAIN_FILE="cmake_32_build.toolchain" -DINGAMEOVERLAY_BUILD_TESTS=OFF -DIMGUI_USER_CONFIG=${{github.workspace}}/tests/common/ingameoverlay_imconfig.h -S . -B build
           cmake --build build -v
           #find build
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         platform: [x32, x64]
-            
+        exclude:
+        - os: macos-latest
+          platform: x32
+          
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
           cmake ${{ github.workspace }}/CMakeLists.txt -DINGAMEOVERLAY_BUILD_TESTS=ON -DIMGUI_USER_CONFIG=${{github.workspace}}/tests/common/ingameoverlay_imconfig.h -S . -B build
-          cmake --build build
+          cmake --build build -v
           #find build
           
       - name: Linux tests (x32)
@@ -52,7 +52,7 @@ jobs:
           EOL
 
           cmake ${{ github.workspace }}/CMakeLists.txt -DCMAKE_TOOLCHAIN_FILE="cmake_32_build.toolchain" -DINGAMEOVERLAY_BUILD_TESTS=ON -DIMGUI_USER_CONFIG=${{github.workspace}}/tests/common/ingameoverlay_imconfig.h -S . -B build
-          cmake --build build
+          cmake --build build -v
           #find build
           
       - name: MacOS tests (x64)
@@ -60,7 +60,7 @@ jobs:
         shell: bash
         run: |
           cmake ${{ github.workspace }}/CMakeLists.txt -DINGAMEOVERLAY_BUILD_TESTS=ON -DIMGUI_USER_CONFIG=${{github.workspace}}/tests/common/ingameoverlay_imconfig.h -S . -B build
-          cmake --build build
+          cmake --build build -v
           #find build
           
       - name: Windows tests (x64)
@@ -68,7 +68,7 @@ jobs:
         shell: powershell
         run: |
           cmake ${{ github.workspace }}\CMakeLists.txt -DINGAMEOVERLAY_BUILD_TESTS=ON -DIMGUI_USER_CONFIG=${{github.workspace}}\tests\common\ingameoverlay_imconfig.h -S . -B build -A x64
-          cmake --build build
+          cmake --build build -v
           #Get-ChildItem -Recurse build
 
       - name: Windows tests (x32)
@@ -76,6 +76,6 @@ jobs:
         shell: powershell
         run: |
           cmake ${{ github.workspace }}\CMakeLists.txt -DINGAMEOVERLAY_BUILD_TESTS=OFF -DIMGUI_USER_CONFIG=${{github.workspace}}\tests\common\ingameoverlay_imconfig.h -S . -B build -A Win32
-          cmake --build build
+          cmake --build build -v
           #Get-ChildItem -Recurse build
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,15 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' && matrix.platform == 'x64' }}
         shell: powershell
         run: |
-          cmake ${{ github.workspace }}\CMakeLists.txt -DINGAMEOVERLAY_BUILD_TESTS=ON -DIMGUI_USER_CONFIG=${{github.workspace}}\tests\common\ingameoverlay_imconfig.h -S . -B build
+          cmake ${{ github.workspace }}\CMakeLists.txt -DINGAMEOVERLAY_BUILD_TESTS=ON -DIMGUI_USER_CONFIG=${{github.workspace}}\tests\common\ingameoverlay_imconfig.h -S . -B build -A x64
           cmake --build build
           #Get-ChildItem -Recurse build
+
+      - name: Windows tests (x32)
+        if: ${{ matrix.os == 'windows-latest' && matrix.platform == 'x32' }}
+        shell: powershell
+        run: |
+          cmake ${{ github.workspace }}\CMakeLists.txt -DINGAMEOVERLAY_BUILD_TESTS=ON -DIMGUI_USER_CONFIG=${{github.workspace}}\tests\common\ingameoverlay_imconfig.h -S . -B build -A Win32
+          cmake --build build
+          #Get-ChildItem -Recurse build
+          

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        platform: [x32, x64]
             
     steps:
       - uses: actions/checkout@v4
@@ -23,8 +24,8 @@ jobs:
           
       - uses: lukka/get-cmake@latest
         
-      - name: Linux tests
-        if: matrix.os == 'ubuntu-latest'
+      - name: Linux tests (x64)
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.platform == 'x64' }}
         shell: bash
         run: |
           sudo apt-get update
@@ -33,16 +34,37 @@ jobs:
           cmake --build build
           #find build
           
-      - name: MacOS tests
-        if: matrix.os == 'macos-latest'
+      - name: Linux tests (x32)
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.platform == 'x32' }}
+        shell: bash
+        run: |
+          sudo apt-get update
+          
+          sudo apt install -y gcc-multilib # needed for 32-bit builds
+          sudo apt install -y g++-multilib
+
+          sudo apt-get install libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+          
+          # write a cmake toolchain file to force 32-bit compilation
+          cat >cmake_32_build.toolchain <<EOL
+          set( CMAKE_C_FLAGS_INIT "-m32" )
+          set( CMAKE_CXX_FLAGS_INIT "-m32" )
+          EOL
+
+          cmake ${{ github.workspace }}/CMakeLists.txt -DCMAKE_TOOLCHAIN_FILE="cmake_32_build.toolchain" -DINGAMEOVERLAY_BUILD_TESTS=ON -DIMGUI_USER_CONFIG=${{github.workspace}}/tests/common/ingameoverlay_imconfig.h -S . -B build
+          cmake --build build
+          #find build
+          
+      - name: MacOS tests (x64)
+        if: ${{ matrix.os == 'macos-latest' && matrix.platform == 'x64' }}
         shell: bash
         run: |
           cmake ${{ github.workspace }}/CMakeLists.txt -DINGAMEOVERLAY_BUILD_TESTS=ON -DIMGUI_USER_CONFIG=${{github.workspace}}/tests/common/ingameoverlay_imconfig.h -S . -B build
           cmake --build build
           #find build
           
-      - name: Windows tests
-        if: matrix.os == 'windows-latest'
+      - name: Windows tests (x64)
+        if: ${{ matrix.os == 'windows-latest' && matrix.platform == 'x64' }}
         shell: powershell
         run: |
           cmake ${{ github.workspace }}\CMakeLists.txt -DINGAMEOVERLAY_BUILD_TESTS=ON -DIMGUI_USER_CONFIG=${{github.workspace}}\tests\common\ingameoverlay_imconfig.h -S . -B build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0048 NEW)
 cmake_policy(SET CMP0091 NEW)
 project(ingame_overlay)
-cmake_minimum_required(VERSION 3.15)
 
 if(WIN32) # Setup some variables for Windows build
   set(INGAMEOVERLAY_SOURCES


### PR DESCRIPTION
This PR does the following
* Add x32 and x64 builds for Linux & Windows
* Allow manually triggering the workflow from Actions tab, helpful in debugging the script itself, also could be used exclusively instead of the `on push` event altogether to save resources if needed
* Update `actions/checkout` to v4 to solve the workflow nag
* Fix a CMake nag because the required minimum version must be added before project definition
* Make the CMake builds verbose, really helpful for looking into args passed to compiler/linker especially when dealing with different ones

Currently tests cannot build on Linux & Windows, but the project actually works on 32-bit Windows (at least for DirectX). I didn't look into how to solve that.

Please feel completely free to close/reject this if not needed.

Partial implementation for #35 